### PR TITLE
Add MessageTemplate manual_archive_date to tests and examples.

### DIFF
--- a/src/mocks.js
+++ b/src/mocks.js
@@ -129,6 +129,7 @@ export const messageTemplates = {
       text: 'Due to the 5k Race, buses will detour off Figueroa from 6pm to 11am on 2/15/17. Find northbound buses on Hope, southbound buses on Flower.',
       start: '2017-02-12T08:00:00-08:00',
       end: '2017-02-15T11:00:00-08:00',
+      manual_archive_date: null,
       sign_messages: [
         {
           id: 1,

--- a/src/resources/MessageTemplate.test.js
+++ b/src/resources/MessageTemplate.test.js
@@ -59,6 +59,7 @@ describe('When creating a message template', () => {
         text: 'Due to the 5k Race, buses will detour off Figueroa from 6pm to 11am on 2/15/17. Find northbound buses on Hope, southbound buses on Flower.',
         start: '2017-02-12T08:00:00-08:00',
         end: '2017-02-15T11:00:00-08:00',
+        manual_archive_date: null,
         sign_messages: [
           {
             override_text: 'Due to the 5k, buses will be on detour.',
@@ -118,6 +119,7 @@ describe('When updating a message template', () => {
         text: 'Due to the 5k Race, buses will detour off Figueroa from 6pm to 11am on 2/15/17. Find northbound buses on Hope, southbound buses on Flower.',
         start: '2017-02-12T08:00:00-08:00',
         end: '2017-02-15T11:00:00-08:00',
+        manual_archive_date: null,
         sign_messages: [
           {
             override_text: 'Due to the 5k, buses will be on detour.',


### PR DESCRIPTION
Advertise the field exists and demonstrate usage for API consumers.