### PR TITLE
Update quickstart guide to reflect project changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ This is the JavaScript client for accessing the [Syncromatics Track API][track-a
 ```javascript
 import Track from 'syncromatics-track-api';
 
-const api = new Track({ apiKey: 'my API key' });
+const api = new Track();
+api.logIn({ apiKey: 'my API key' });
 
 api.customer('SYNC').vehicles()
   .withQuery('01234')
   .getPage()
   .then(vehicles => /* work with vehicles */);
 ```
+
+You can also log in with a username and password or a previously-generated JWT token.  See the
+[logIn documentation][login-docs] for more detail.
 
 ## Documentation
 
@@ -30,6 +34,6 @@ Generated documentation is available on the [project page][project-page]
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for our guide to contributing and code of conduct.
 
-
 [project-page]: http://syncromatics.github.io/syncromatics-track-api
+[login-docs]: http://syncromatics.github.io/syncromatics-track-api#tracklogin
 [track-api-docs]: http://docs.syncromaticstrackapi.apiary.io


### PR DESCRIPTION
`options.apiKey` is now passed in `Track#logIn` instead of `Track` constructor.