### PR TITLE
feat(voip): Support voip heartbeats 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,6 +500,7 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-glob": "^2.0.0"
           }
@@ -574,7 +575,8 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-dotfile": {
           "version": "1.0.3",
@@ -604,7 +606,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-finite": {
           "version": "1.0.2",
@@ -620,6 +623,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -652,7 +656,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isobject": {
           "version": "2.1.0",
@@ -687,6 +692,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -763,6 +769,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -955,13 +962,15 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
           "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "repeat-element": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
           "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "repeat-string": {
           "version": "1.6.1",
@@ -983,7 +992,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "set-immediate-shim": {
           "version": "1.0.1",
@@ -8351,7 +8361,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -8402,7 +8413,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -8426,6 +8438,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -8434,6 +8447,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -8475,7 +8489,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -8589,12 +8604,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -8650,6 +8667,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -8662,7 +8680,8 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -8701,7 +8720,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -8718,6 +8738,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -8726,7 +8747,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -8842,6 +8864,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8849,12 +8872,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8928,6 +8953,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8957,7 +8983,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -9052,6 +9079,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -9144,6 +9172,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9244,7 +9273,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15287,6 +15317,11 @@
           }
         }
       }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vfile-message": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "jwt-client": "^0.2.1",
     "parse-link-header": "^0.4.1",
     "qs": "^6.3.0",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "uuid": "^3.3.2"
   },
   "repository": {
     "type": "git",

--- a/src/examples/subscribe_call_states.test.js
+++ b/src/examples/subscribe_call_states.test.js
@@ -7,7 +7,7 @@ import { charlie, realTime as realTimeMocks } from '../mocks';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('When subscribing to call requests', () => {
+describe('When subscribing to call states', () => {
   let server;
   const api = new Track({
     autoRenew: false,
@@ -22,18 +22,18 @@ describe('When subscribing to call requests', () => {
   afterEach(fetchMock.restore);
   after(() => server.close());
 
-  it('should get updated call requests for a single vehicle', () => {
+  it('should get updated call states for a single vehicle', () => {
     const vehicleHref = '1/SYNC/vehicles/123';
 
     api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
     return api.customer('SYNC')
       .realTime()
-      .callRequests()
+      .callStates()
       .forVehicle(vehicleHref)
-      .on('update', callRequest => callRequest); // do things with call request
+      .on('update', callState => callState); // do things with callState
   });
 
-  it('should get updated call requests for multiple vehicles', () => {
+  it('should get updated call states for multiple vehicles', () => {
     const vehicles = [
       { href: '1/SYNC/vehicles/123' },
       { href: '1/SYNC/vehicles/456' },
@@ -44,8 +44,8 @@ describe('When subscribing to call requests', () => {
     api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
     return api.customer('SYNC')
       .realTime()
-      .callRequests()
+      .callStates()
       .forVehicles(vehicles)
-      .on('update', callRequest => callRequest); // do things with callRequest
+      .on('update', callState => callState); // do things with callState
   });
 });

--- a/src/mocks/callStates.js
+++ b/src/mocks/callStates.js
@@ -1,6 +1,6 @@
 // currently only  used in realtime mocks, so only need .list
 
-const callRequests = {
+const callStates = {
   list: [
     {
       vehicle: { href: '/1/SYNC/vehicles/1' },
@@ -13,4 +13,4 @@ const callRequests = {
   ],
 };
 
-export default callRequests;
+export default callStates;

--- a/src/mocks/realTime.js
+++ b/src/mocks/realTime.js
@@ -2,7 +2,7 @@
 import { Server } from 'mock-socket';
 import * as messages from '../subscriptions/messages';
 import areas from './areas';
-import callRequests from './callRequests';
+import callStates from './callStates';
 import dispatchMessages from './dispatchMessages';
 import signs from './signs';
 import stopArrivals from './stopArrivals';
@@ -125,8 +125,8 @@ const realTime = {
           case 'ASSIGNMENTS':
             data = vehicles.list.map(v => v.assignment);
             break;
-          case 'CALL_REQUESTS':
-            data = callRequests.list;
+          case 'CALL_STATES':
+            data = callStates.list;
             break;
           case 'DISPATCH_MESSAGES':
             data = dispatchMessages.list;

--- a/src/resources/CallStatesRealTimeContext.js
+++ b/src/resources/CallStatesRealTimeContext.js
@@ -1,16 +1,16 @@
 import RealTimeContext from './RealTimeContext';
 
 /**
- * A real time context that can be used to generate subscriptions to Call REquest entities.
+ * A real time context that can be used to generate subscriptions to Call State entities.
  */
-class CallRequestsRealTimeContext extends RealTimeContext {
+class CallStatesRealTimeContext extends RealTimeContext {
   /**
-   * Creates a context that can subscribe to Call Request updates.
+   * Creates a context that can subscribe to Call State updates.
    * @param {RealTimeClient} realTimeClient  Pre-configured instance of RealTimeClient.
    * @param {string} customerCode The customer code to query for updates.
    */
   constructor(realTimeClient, customerCode) {
-    const entityName = 'CALL_REQUESTS';
+    const entityName = 'CALL_STATES';
     super(realTimeClient, entityName, customerCode);
     this.filters = {
       vehicles: [],
@@ -20,7 +20,7 @@ class CallRequestsRealTimeContext extends RealTimeContext {
   /**
    * Restrict subscriptions created by this context to a single vehicle.
    * @param {Resource|string} vehicle Href or resource representation of a Vehicle.
-   * @returns {CallRequestsRealTimeContext} Context with filter applied.
+   * @returns {CallStatesRealTimeContext} Context with filter applied.
    */
   forVehicle(vehicle) {
     return this.forVehicles([vehicle]);
@@ -30,7 +30,7 @@ class CallRequestsRealTimeContext extends RealTimeContext {
    * Restrict subscriptions created by this context to a set of vehicles.
    * @param {Array.<Resource|string>} vehicles Array of href or resource representations of
    * Vehicles.
-   * @returns {CallRequestsRealTimeContext} Context with filter applied.
+   * @returns {CallStatesRealTimeContext} Context with filter applied.
    */
   forVehicles(vehicles) {
     this.assertSubscriptionNotStarted();
@@ -39,4 +39,4 @@ class CallRequestsRealTimeContext extends RealTimeContext {
   }
 }
 
-export default CallRequestsRealTimeContext;
+export default CallStatesRealTimeContext;

--- a/src/resources/CallStatesRealTimeContext.test.js
+++ b/src/resources/CallStatesRealTimeContext.test.js
@@ -1,20 +1,20 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import CallRequestsRealTimeContext from './CallRequestsRealTimeContext';
+import CallStatesRealTimeContext from './CallStatesRealTimeContext';
 import RealTimeClient from '../RealTimeClient';
 import { realTime as mock } from '../mocks';
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('When creating a subscription for Call Requests', () => {
-  const entity = 'CALL_REQUESTS';
+describe('When creating a subscription for Call States', () => {
+  const entity = 'CALL_STATES';
   const customerCode = 'SYNC';
 
   it('can add filters for a single vehicle', () => {
     const server = mock.getServer();
     const realTimeClient = new RealTimeClient(mock.authenticatedClient, mock.options);
-    const subject = new CallRequestsRealTimeContext(realTimeClient, customerCode);
+    const subject = new CallStatesRealTimeContext(realTimeClient, customerCode);
 
     const vehicleHref = '123';
     const expectedFilters = { vehicles: [vehicleHref] };
@@ -28,7 +28,7 @@ describe('When creating a subscription for Call Requests', () => {
   it('can add filters for multiple vehicles', () => {
     const server = mock.getServer();
     const realTimeClient = new RealTimeClient(mock.authenticatedClient, mock.options);
-    const subject = new CallRequestsRealTimeContext(realTimeClient, customerCode);
+    const subject = new CallStatesRealTimeContext(realTimeClient, customerCode);
 
     const vehicleHrefs = ['123', '456', '489'];
     const expectedFilters = { vehicles: vehicleHrefs };
@@ -43,7 +43,7 @@ describe('When creating a subscription for Call Requests', () => {
   it('should handle entity updates', () => {
     const server = mock.getServer();
     const realTimeClient = new RealTimeClient(mock.authenticatedClient, mock.options);
-    const subject = new CallRequestsRealTimeContext(realTimeClient, customerCode);
+    const subject = new CallStatesRealTimeContext(realTimeClient, customerCode);
 
     let resolver;
     const updateReceived = new Promise((resolve) => {

--- a/src/resources/RealTimeContextFactory.js
+++ b/src/resources/RealTimeContextFactory.js
@@ -3,11 +3,12 @@ import AssignmentsRealTimeContext from './AssignmentsRealTimeContext';
 import CallStatesRealTimeContext from './CallStatesRealTimeContext';
 import DispatchMessagesRealTimeContext from './DispatchMessagesRealTimeContext';
 import SignsRealTimeContext from './SignsRealTimeContext';
+import StopsRealTimeContext from './StopsRealTimeContext';
 import StopArrivalsRealTimeContext from './StopArrivalsRealTimeContext';
 import StopTimesRealTimeContext from './StopTimesRealTimeContext';
 import VehicleArrivalsRealTimeContext from './VehicleArrivalsRealTimeContext';
 import VehiclesRealTimeContext from './VehiclesRealTimeContext';
-import StopsRealTimeContext from './StopsRealTimeContext';
+import VoipHeartbeatHandler from './VoipHeartbeatHandler';
 
 /**
  * A factory for creating entity-specific Real Time Contexts for a given Real Time Client.
@@ -110,6 +111,15 @@ class RealTimeContextFactory {
    */
   vehicles() {
     return new VehiclesRealTimeContext(this.realTimeClient, this.customerCode);
+  }
+
+  /**
+   * Creates a VoipHeartbeatHandler for sending current VOIP call state and receiving
+   * desired VOIP call state over heartbeats.
+   * @returns {VoipHeartbeatHandler} The newly created handler.
+   */
+  voip() {
+    return new VoipHeartbeatHandler(this.realTimeClient, this.customerCode);
   }
 }
 

--- a/src/resources/RealTimeContextFactory.js
+++ b/src/resources/RealTimeContextFactory.js
@@ -1,6 +1,6 @@
 import AreasRealTimeContext from './AreasRealTimeContext';
 import AssignmentsRealTimeContext from './AssignmentsRealTimeContext';
-import CallRequestsRealTimeContext from './CallRequestsRealTimeContext';
+import CallStatesRealTimeContext from './CallStatesRealTimeContext';
 import DispatchMessagesRealTimeContext from './DispatchMessagesRealTimeContext';
 import SignsRealTimeContext from './SignsRealTimeContext';
 import StopArrivalsRealTimeContext from './StopArrivalsRealTimeContext';
@@ -49,11 +49,11 @@ class RealTimeContextFactory {
   }
 
   /**
-   * Creates a RealTimeContext for querying Call Request updates.
-   * @returns {CallRequestsRealTimeContext} The newly created context.
+   * Creates a RealTimeContext for querying Call State updates.
+   * @returns {CallStatesRealTimeContext} The newly created context.
    */
-  callRequests() {
-    return new CallRequestsRealTimeContext(this.realTimeClient, this.customerCode);
+  callStates() {
+    return new CallStatesRealTimeContext(this.realTimeClient, this.customerCode);
   }
 
   /**

--- a/src/resources/RealTimeContextFactory.test.js
+++ b/src/resources/RealTimeContextFactory.test.js
@@ -23,8 +23,8 @@ describe('When creating a RealTimeContext', () => {
     result.realTimeClient.should.equal(realTimeClient);
   });
 
-  it('should reuse its RealTimeClient when creating an CallRequestsRealTimeContext', () => {
-    const result = factory.callRequests();
+  it('should reuse its RealTimeClient when creating an CallStatesRealTimeContext', () => {
+    const result = factory.callStates();
     result.realTimeClient.should.equal(realTimeClient);
   });
 

--- a/src/resources/RealTimeContextFactory.test.js
+++ b/src/resources/RealTimeContextFactory.test.js
@@ -47,4 +47,9 @@ describe('When creating a RealTimeContext', () => {
     const result = factory.vehicles();
     result.realTimeClient.should.equal(realTimeClient);
   });
+
+  it('should reuse its RealTimeClient when creating a VoipHeartbeatHandler', () => {
+    const result = factory.voip();
+    result.realTimeClient.should.equal(realTimeClient);
+  });
 });

--- a/src/resources/VoipHeartbeatHandler.js
+++ b/src/resources/VoipHeartbeatHandler.js
@@ -1,0 +1,210 @@
+import { v4 as uuidv4 } from 'uuid';
+
+const deafultHeartbeatIntervalMs = 15 * 1000;
+const deafultHeartbeatReadTimeoutMs = 45 * 1000;
+
+const validCallStates = {
+  None: 'None',
+  OnCall: 'OnCall',
+};
+
+const isValidCallState = (callState, callHref) => {
+  if (!Object.keys(validCallStates).includes(callState)) {
+    return false;
+  }
+
+  return (callState === validCallStates.None)
+    || (typeof callHref === 'string' && callHref !== '');
+};
+
+const getHeartbeat = (voipHeartbeatHandler) => {
+  const now = new Date().toISOString();
+  const { customerCode, sessionId, callState, callHref } = voipHeartbeatHandler;
+  return {
+    type: 'HEARTBEAT',
+    at_time: now,
+    session_id: sessionId,
+    customer: customerCode,
+    current_call_state: callState,
+    current_call_href: callHref,
+  };
+};
+
+class VoipHeartbeatHandler {
+  constructor(realTimeClient, customerCode, options = {}) {
+    this.realTimeClient = realTimeClient;
+    this.customerCode = customerCode;
+
+    // uuidv4 is randomly generated.
+    this.sessionId = uuidv4();
+    this.callState = validCallStates.None;
+    this.callHref = '';
+    this.handlers = {};
+
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs || deafultHeartbeatIntervalMs;
+    this.heartbeatReadTimeoutMs = options.heartbeatReadTimeoutMs || deafultHeartbeatReadTimeoutMs;
+
+    this.setCallState = this.setCallState.bind(this);
+    this.sendHeartbeat = this.sendHeartbeat.bind(this);
+    this.readHeartbeat = this.readHeartbeat.bind(this);
+    this.onHeartbeatTimeout = this.onHeartbeatTimeout.bind(this);
+
+    this.realTimeClient.registerHeartbeatHandler(this.readHeartbeat);
+  }
+
+  /**
+   * Sets the current actual call state to be sent along with heartbeats.
+   * @param {CallState} callState The actual current call state
+   * @param {string} callHref The actual current call href, if any
+   * @returns {void}
+   */
+  setCallState(callState, callHref) {
+    if (!isValidCallState(callState, callHref)) {
+      throw new Error('Invalid call state.');
+    }
+
+    const {
+      callState: oldCallState,
+      callHref: oldCallHref,
+    } = this;
+
+    this.callState = callState;
+    this.callHref = callHref;
+
+    if (oldCallState !== callState || oldCallHref !== callHref) {
+      this.sendHeartbeat(this);
+    }
+  }
+
+  onHeartbeatTimeout() {
+    if (!this.running) return;
+
+    const { onDisconnect } = this.handlers;
+    if (typeof onDisconnect === 'function') {
+      onDisconnect();
+    }
+
+    this.realTimeClient.closeConnection({ shouldReconnect: true });
+  }
+
+  readHeartbeat(heartbeat) {
+    if (!this.running) return;
+
+    const { heartbeatReadTimeoutMs } = this;
+    if (this.heartbeatTimeoutInterval) {
+      clearTimeout(this.heartbeatTimeoutInterval);
+    }
+    this.heartbeatTimeoutInterval = setTimeout(this.onHeartbeatTimeout, heartbeatReadTimeoutMs);
+
+    const {
+      desired_call_state: desiredCallState,
+      desired_call_href: desiredCallHref,
+    } = heartbeat;
+    const {
+      previousDesiredCallState,
+      previousDesiredCallHref,
+    } = this;
+
+    const hasDesiredCallStateChanged =
+      desiredCallState !== previousDesiredCallState || desiredCallHref !== previousDesiredCallHref;
+
+    if (hasDesiredCallStateChanged) {
+      this.previousDesiredCallState = desiredCallState;
+      this.previousDesiredCallHref = desiredCallHref;
+
+      const { onDesiredCallStateChange: onChange } = this.handlers;
+      if (typeof onChange === 'function') {
+        onChange(desiredCallState, desiredCallHref);
+      }
+    }
+  }
+
+  sendHeartbeat() {
+    if (!this.running) return;
+
+    const self = this;
+    const { heartbeatIntervalMs } = self;
+
+    if (this.heartbeatTimeout) {
+      clearTimeout(this.heartbeatTimeout);
+    }
+
+    // sendMessage returns a promise that resolves once the message is
+    // actually sent.  wait until then until we queue up the next
+    // heartbeat.
+    const heartbeat = getHeartbeat(self);
+    self.realTimeClient
+      .sendMessage(heartbeat)
+      .then(() => {
+        self.heartbeatTimeout = setTimeout(self.sendHeartbeat, heartbeatIntervalMs);
+      });
+  }
+
+  /**
+   * Registers a handler function to be called when the call state changes.
+   * Handler will be called with the desired call state and call href.
+   * @param {function} handler - function(callState, callHref)
+   * @returns {VoipHeartbeatHandler} This VoipHeartbeatHandler
+   */
+  onDesiredCallStateChange(handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('Must pass a function handler to onDesiredCallStateChange.');
+    }
+    this.handlers.onDesiredCallStateChange = handler;
+    return this;
+  }
+
+  /**
+   * Set a handler to be run after detecting a disconnect from the server.
+   * Overwrites any previously set handler, if any.
+   * @param {function} handler The function to run
+   * @returns {VoipHeartbeatHandler} returns itself.
+   */
+  onDisconnect(handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('Must pass a function handler to onDisconnect.');
+    }
+    this.handlers.onDisconnect = handler;
+    return this;
+  }
+
+  /**
+   * Set a handler to be run after successfully reconnecting to the server.
+   * Overwrites any previously set handler, if any.
+   * @param {function} handler The function to run
+   * @returns {VoipHeartbeatHandler} returns itself.
+   */
+  onReconnect(handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('Must pass a function handler to onReconnect.');
+    }
+    this.handlers.reconnect = handler;
+    return this;
+  }
+
+  /**
+   * Start sending VoIP heartbeat messages to the Track API server.
+   * @returns {VoipHeartbeatHandler} returns itself.
+   */
+  startHeartbeat() {
+    this.running = true;
+    this.sendHeartbeat();
+    return this;
+  }
+
+  /**
+   * Stop sending VoIP heartbeat messages to the Track API server.
+   * @returns {VoipHeartbeatHandler} returns itself.
+   */
+  stopHeartbeat() {
+    this.running = false;
+    if (this.heartbeatTimeoutInterval) {
+      clearTimeout(this.heartbeatTimeoutInterval);
+    }
+    if (this.heartbeatTimeout) {
+      clearTimeout(this.heartbeatTimeout);
+    }
+  }
+}
+
+export default VoipHeartbeatHandler;

--- a/src/resources/VoipHeartbeatHandler.test.js
+++ b/src/resources/VoipHeartbeatHandler.test.js
@@ -1,0 +1,108 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import VoipHeartbeatHandler from './VoipHeartbeatHandler';
+import RealTimeClient from '../RealTimeClient';
+import { realTime as mock } from '../mocks';
+import * as messages from '../subscriptions/messages';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const customerCode = 'SYNC';
+
+describe('When sending and receiving heartbeats', () => {
+  let server;
+  let realTimeClient;
+  let subject;
+
+  beforeEach(() => {
+    server = mock.getServer();
+    realTimeClient = new RealTimeClient(mock.authenticatedClient, mock.options);
+    subject = new VoipHeartbeatHandler(realTimeClient, customerCode, {
+      heartbeatIntervalMs: 100,
+      heartbeatReadTimeoutMs: 100,
+    });
+  });
+
+  afterEach(() => {
+    subject.stopHeartbeat();
+    server.closeConnection();
+  });
+
+  const sendServerHeartbeat = () => server.emit('message', JSON.stringify({
+    type: messages.HEARTBEAT,
+    at_time: new Date().toISOString(),
+    desired_call_state: 'OnCall',
+    desired_call_href: '/1/SYNC/calls/123',
+  }));
+
+  it('should send heartbeats periodically', () => {
+    let resolver;
+    const promise = new Promise((x) => { resolver = x; });
+
+    let receivedHeartbeats = 0;
+
+    server.onTrackMessage(messages.HEARTBEAT, () => {
+      receivedHeartbeats += 1;
+      if (receivedHeartbeats === 2) resolver();
+    });
+
+    subject.startHeartbeat();
+
+    return promise.should.eventually.be.fulfilled;
+  });
+
+  it('should send current call state along the heartbeat', () => {
+    let receivedResolver;
+    const received = new Promise((resolver) => { receivedResolver = resolver; });
+    subject.startHeartbeat();
+
+    const expectedCallState = 'OnCall';
+    const expectedCallHref = '/1/SYNC/calls/123';
+    subject.setCallState(expectedCallState, expectedCallHref);
+
+    server.onTrackMessage(messages.HEARTBEAT, (heartbeat) => {
+      const {
+        current_call_state: callState,
+        current_call_href: callHref,
+      } = heartbeat;
+      if (callState === expectedCallState && callHref === expectedCallHref) {
+        receivedResolver(heartbeat);
+      }
+    });
+
+    return received.should.eventually.be.fulfilled;
+  });
+
+  it('should run the onDisconnect handler', () => {
+    let onDisconnectResolver;
+    const onDisconnectPromise = new Promise((resolver) => { onDisconnectResolver = resolver; });
+
+    subject
+      .onDisconnect(onDisconnectResolver)
+      .startHeartbeat();
+
+    // sending this once starts the countdown timer...
+    sendServerHeartbeat();
+
+    return onDisconnectPromise.should.be.fulfilled;
+  });
+
+  it('should run the call state change handler', () => {
+    let stateChangeResolver;
+    const stateChangePromise = new Promise((resolver) => { stateChangeResolver = resolver; });
+
+    subject
+      .onDesiredCallStateChange((callState, callHref) => {
+        stateChangeResolver({
+          callState,
+          callHref,
+        });
+      })
+      .startHeartbeat();
+
+    sendServerHeartbeat();
+
+    return stateChangePromise.should.be.fulfilled;
+  });
+});

--- a/src/subscriptions/messages.js
+++ b/src/subscriptions/messages.js
@@ -23,6 +23,8 @@ export const ENTITY = {
   DELETE: 'ENTITY_DELETE',
 };
 
+export const HEARTBEAT = 'HEARTBEAT';
+
 /**
  * Creates a Track Real Time API control message for authenticating a connection.
  * @param {string} jwt A pre-authenticated JSON Web Token for authorizing this connection.


### PR DESCRIPTION
feat(voip): Support voip heartbeats 

Added .customer().realTime().voip() heartbeat handler.

BREAKING CHANGE: now subscribes to callStates instead of callRequests

Updated to address changes in Track API.

Before:

api.customer('SYNC')
      .realTime()
      .callRequests()
      .on('update', callRequest => callRequest);

After:

api.customer('SYNC')
      .realTime()
      .callStates()
      .on('update', callState => callState);

Signed-off-by: Jeff Cuevas-Koch <jeff@cuevaskoch.com>