### PR TITLE
feat(reconnect): Attach disconnect and reconnect handlers.

### DIFF
--- a/src/RealTimeClient.test.js
+++ b/src/RealTimeClient.test.js
@@ -204,4 +204,23 @@ describe('When the real time connection is disconnected', () => {
       lastSubscription.should.eventually.become(2),
     ]);
   });
+
+  it('should fire disconnect and reconnect event handlers', () => {
+    let resolveDisconnectEvent;
+    const disconnectEvent = new Promise((resolve) => { resolveDisconnectEvent = resolve; });
+    let resolveReconnectEvent;
+    const reconnectEvent = new Promise((resolve) => { resolveReconnectEvent = resolve; });
+
+    realTimeClient.addEventListener('disconnect', resolveDisconnectEvent);
+    realTimeClient.addEventListener('reconnect', resolveReconnectEvent);
+
+    const startAndRestart = realTimeClient.sendMessage({ type: 'TEST', id: 1 })
+      .then(reconnect);
+
+    return Promise.all([
+      startAndRestart,
+      disconnectEvent,
+      reconnectEvent,
+    ]);
+  });
 });

--- a/src/examples/subscribe_call_states.test.js
+++ b/src/examples/subscribe_call_states.test.js
@@ -59,5 +59,5 @@ describe('When subscribing to call states', () => {
       .callStates()
       .forUser(user)
       .on('update', callState => callState); // do things with callState
-  })
+  });
 });

--- a/src/mocks/roles.js
+++ b/src/mocks/roles.js
@@ -11,20 +11,10 @@ const roles = {
         },
       });
     const singleResponse = () => new Response(Client.toBlob(roles.getById(2)));
-    const postResponse = () => new Response(undefined, {
-      headers: {
-        Location: '/1/roles/4',
-      },
-    });
-    const putResponse = id => () => new Response(undefined, {
-      headers: {
-        Location: `/1/roles/${id}`,
-      },
-    });
 
     fetchMock
       .get(client.resolve('/1/roles?page=1&per_page=10&q=Di&sort='), listResponse)
-      .get(client.resolve('/1/roles/2'), singleResponse)
+      .get(client.resolve('/1/roles/2'), singleResponse);
   },
   getById: id => roles.list.find(x => x.id === id),
   list: [

--- a/src/resources/RealTimeContextFactory.js
+++ b/src/resources/RealTimeContextFactory.js
@@ -36,6 +36,33 @@ class RealTimeContextFactory {
   }
 
   /**
+   * Attaches a global event handler to be fired when the real time client disconnects unexpectedly.
+   * @param {function} handler The handler to be fired.
+   * @returns {function} A function that, when called, will remove the event handler.
+   */
+  onDisconnect(handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('handler must be a function.');
+    }
+    this.realTimeClient.addEventListener('disconnect', handler);
+    return () => this.realTimeClient.removeEventListener('disconnect', handler);
+  }
+
+  /**
+   * Attaches a global event handler to be fired when the real time client reconnects after an
+   * unexpected disconnection.
+   * @param {function} handler The handler to be fired.
+   * @returns {function} A function that, when called, will remove the event handler.
+   */
+  onReconnect(handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('handler must be a function.');
+    }
+    this.realTimeClient.addEventListener('reconnect', handler);
+    return () => this.realTimeClient.removeEventListener('reconnect', handler);
+  }
+
+  /**
    * Creates a RealTimeContext for querying Area updates.
    * @returns {AreasRealTimeContext} The newly created context.
    */

--- a/src/resources/RealTimeContextFactory.test.js
+++ b/src/resources/RealTimeContextFactory.test.js
@@ -53,3 +53,79 @@ describe('When creating a RealTimeContext', () => {
     result.realTimeClient.should.equal(realTimeClient);
   });
 });
+
+describe('When attaching disconnect and reconnect handlers', () => {
+  const customerCode = 'SYNC';
+
+  it('should attach disconnect handlers to the realTimeClient', () => {
+    const disconnectHandler = () => {};
+    let verifyCallback;
+    const didVerifyCallback = new Promise((resolve) => { verifyCallback = resolve; });
+    const realTimeClientMock = {
+      addEventListener: (event, handler) => {
+        if (event === 'disconnect' && handler === disconnectHandler) {
+          verifyCallback(true);
+        }
+      }
+    }
+    const factory = new RealTimeContextFactory(realTimeClientMock, customerCode);
+
+    factory.onDisconnect(disconnectHandler);
+    didVerifyCallback.should.become(true);
+  });
+
+  it('should remove disconnect handlers', () => {
+    const disconnectHandler = () => {};
+    let verifyCallback;
+    const didVerifyCallback = new Promise((resolve) => { verifyCallback = resolve; });
+    const realTimeClientMock = {
+      addEventListener: () => {},
+      removeEventListener: (event, handler) => {
+        if (event === 'disconnect' && handler === disconnectHandler) {
+          verifyCallback(true);
+        }
+      }
+    }
+    const factory = new RealTimeContextFactory(realTimeClientMock, customerCode);
+
+    const handlerRemover = factory.onDisconnect(disconnectHandler);
+    handlerRemover();
+    didVerifyCallback.should.become(true);
+  });
+
+  it('should fire reconnect handlers', () => {
+    const reconnectHandler = () => {};
+    let verifyCallback;
+    const didVerifyCallback = new Promise((resolve) => { verifyCallback = resolve; });
+    const realTimeClientMock = {
+      addEventListener: (event, handler) => {
+        if (event === 'reconnect' && handler === reconnectHandler) {
+          verifyCallback(true);
+        }
+      }
+    }
+    const factory = new RealTimeContextFactory(realTimeClientMock, customerCode);
+
+    factory.onReconnect(reconnectHandler);
+    didVerifyCallback.should.become(true);
+  });
+
+  it('should remove reconnect handlers', () => {
+    const reconnectHandler = () => {};
+    let verifyCallback;
+    const didVerifyCallback = new Promise((resolve) => { verifyCallback = resolve; });
+    const realTimeClientMock = {
+      addEventListener: () => {},
+      removeEventListener: (event, handler) => {
+        if (event === 'reconnect' && handler === reconnectHandler) {
+          verifyCallback(true);
+        }
+      }
+    }
+    const factory = new RealTimeContextFactory(realTimeClientMock, customerCode);
+
+    const handlerRemover = factory.onReconnect(reconnectHandler);
+    handlerRemover();
+    didVerifyCallback.should.become(true);
+  });
+});


### PR DESCRIPTION
Allow handlers to be attached to the RealTimeClient to be fired in case of an
unexpected disconnect or an ensuing reconnect.  Handlers are attached through
the RealTimeContextFactory to provide a uniform interface.

This commit also cleans up all linting errors.

Supports EN-4172.

Signed-off-by: Jeff Cuevas-Koch <jcuevas-koch@gmvsync.com>