### PR TITLE
fix(voip): Added support for passing options into VoipHeartbeatHandler from the RealTimeContextFactory

### DIFF
--- a/src/resources/RealTimeContextFactory.js
+++ b/src/resources/RealTimeContextFactory.js
@@ -161,10 +161,11 @@ class RealTimeContextFactory {
   /**
    * Creates a VoipHeartbeatHandler for sending current VOIP call state and receiving
    * desired VOIP call state over heartbeats.
+   * @param {Object} options Options for the handler
    * @returns {VoipHeartbeatHandler} The newly created handler.
    */
-  voip() {
-    return new VoipHeartbeatHandler(this.realTimeClient, this.customerCode);
+  voip(options) {
+    return new VoipHeartbeatHandler(this.realTimeClient, this.customerCode, options);
   }
 }
 

--- a/src/resources/VoipHeartbeatHandler.js
+++ b/src/resources/VoipHeartbeatHandler.js
@@ -30,7 +30,21 @@ const getHeartbeat = (voipHeartbeatHandler) => {
   };
 };
 
+/**
+ * Handler for VOIP call state and receiving desired VOIP call state over heartbeats.
+ */
 class VoipHeartbeatHandler {
+  /**
+   * Creates a VoipHeartbeatHandler for sending current VOIP call state and receiving
+   * desired VOIP call state over heartbeats.
+   * @param {RealTimeClient} realTimeClient A pre-configured instance of RealTimeClient.
+   * @param {string} customerCode The customer code for this real-time context.
+   * @param {Object} options Options for the handler
+   * @param {number} [options.heartbeatIntervalMs] The minimum interval to send heartbeats to
+   * Track API
+   * @param {number} [options.heartbeatReadTimeoutMs] The time to wait for receiving a heartbeat
+   * from Track API
+   */
   constructor(realTimeClient, customerCode, options = {}) {
     this.realTimeClient = realTimeClient;
     this.customerCode = customerCode;


### PR DESCRIPTION
All the other plumbing was in place to support this. Just needed to allow passing options from the `voip()` function.

EN-5277