### PR TITLE
fix(reconnect): return from onConnectionOpened if connection is not open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 dist
 node_modules
+.idea

--- a/src/RealTimeClient.js
+++ b/src/RealTimeClient.js
@@ -199,6 +199,10 @@ class RealTimeClient {
    * @returns {void}
    */
   onConnectionOpened() {
+    if (this.connection.readyState !== WEBSOCKET_READY_STATES.OPEN) {
+      console.error(`onConnectionOpened fired but WS Connection is ${this.connection.readyState}. Restarting connection.`);
+      return;
+    }
     this.initializing = false;
     if (this.isInReconnectLoop) {
       delete this.isInReconnectLoop;


### PR DESCRIPTION
When pods roll this can happen. Safety checking to make sure WS is OPEN helps prevent things getting gunked up when queuedMessages get sent off after ws authorization.

![sync-reconnect-fix](https://user-images.githubusercontent.com/14823852/86085957-54728800-ba55-11ea-9495-3319ff14aad0.gif)
