### PR TITLE
feat(maintenance): Expand non-browser support.

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -94,7 +94,10 @@ class Client {
     }
 
     const opts = {
-      headers: {},
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
       method,
       body,
       ...rest,


### PR DESCRIPTION
Set default `Content-Type` and `Accept` headers to `application/json`
since this is not done automatically in some non-browser environments.

Signed-off-by: Jeff Cuevas-Koch <jcuevas-koch@gmvsync.com>