### PR TITLE
feat(voip): Expose isMuted on VOIP heartbeats.

### DIFF
--- a/src/examples/create_and_end_calls.test.js
+++ b/src/examples/create_and_end_calls.test.js
@@ -41,7 +41,7 @@ describe('When creating a call', () => {
   it('should create a call', () => {
     api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
 
-    const callPromise = api.customer('SYNC').call({ initiating_user: '/1/users/1' })
+    const callPromise = api.customer('SYNC').call({ initiating_user: { href: '/1/users/1' } })
       .create()
       .then(call => call); // Do things with call
 
@@ -80,7 +80,7 @@ describe('When adding a participant to a call', () => {
     api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
 
     const callId = 2;
-    const newParticipant = { type: 'user', user: '/1/SYNC/users/1' };
+    const newParticipant = { type: 'user', user: { href: '/1/SYNC/users/1' }};
     const participantPromise = api.customer('SYNC').callParticipant(callId, newParticipant)
       .create()
       .then(participant => participant);

--- a/src/mocks/callParticipants.js
+++ b/src/mocks/callParticipants.js
@@ -31,7 +31,7 @@ const callParticipants = {
       connection_requested: new Date().toISOString(),
       connection_established: undefined,
       connection_terminated: undefined,
-      user: '/1/SYNC/users/1',
+      user: { href: '/1/SYNC/users/1' },
     },
     {
       href: '/1/SYNC/calls/2/participants/4',
@@ -42,7 +42,7 @@ const callParticipants = {
       connection_requested: new Date().toISOString(),
       connection_established: undefined,
       connection_terminated: undefined,
-      vehicle: '/1/SYNC/vehicles/1',
+      vehicle: { href: '/1/SYNC/vehicles/1' },
     },
   ],
 };

--- a/src/mocks/calls.js
+++ b/src/mocks/calls.js
@@ -25,7 +25,7 @@ const calls = {
     id: 3,
     started: new Date().toISOString(),
     ended: undefined,
-    initiating_user: '/1/users/1',
+    initiating_user: { href: '/1/users/1' },
     participants: [
       {
         href: '/1/SYNC/calls/3/participants/1',
@@ -35,7 +35,7 @@ const calls = {
         connection_requested: new Date().toISOString(),
         connection_established: undefined,
         connection_terminated: undefined,
-        user: '/1/SYNC/users/1',
+        user: { href: '/1/SYNC/users/1' },
       },
       {
         href: '/1/SYNC/calls/3/participants/2',
@@ -45,7 +45,7 @@ const calls = {
         connection_requested: new Date().toISOString(),
         connection_established: undefined,
         connection_terminated: undefined,
-        vehicle: '/1/SYNC/vehicles/1',
+        vehicle: { href: '/1/SYNC/vehicles/1' },
       },
     ],
   }],

--- a/src/resources/Call.test.js
+++ b/src/resources/Call.test.js
@@ -52,7 +52,7 @@ describe('When creating a call', () => {
 
   let promise;
   beforeEach(() => {
-    promise = new Call(client, { code: 'SYNC', initiating_user: '/1/users/1' }).create();
+    promise = new Call(client, { code: 'SYNC', initiating_user: { href: '/1/users/1' } }).create();
   });
 
   it('should resolve the promise', () => promise.should.be.fulfilled);
@@ -69,7 +69,7 @@ describe('When updating a call', () => {
 
   let promise;
   beforeEach(() => {
-    promise = new Call(client, { code: 'SYNC', initiating_user: '/1/users/1' })
+    promise = new Call(client, { code: 'SYNC', initiating_user: { href: '/1/users/1' } })
       .create()
       .then(call => call.end()
         .then(() => call));

--- a/src/resources/CallParticipant.test.js
+++ b/src/resources/CallParticipant.test.js
@@ -52,7 +52,7 @@ describe('When adding a call participant', () => {
 
   let promise;
   beforeEach(() => {
-    promise = new CallParticipant(client, { code: 'SYNC', callId: 2, user: '/1/SYNC/users/1' }).create();
+    promise = new CallParticipant(client, { code: 'SYNC', callId: 2, user: { href: '/1/SYNC/users/1' } }).create();
   });
 
   it('should resolve the promise', () => promise.should.be.fulfilled);
@@ -69,7 +69,7 @@ describe('When updating a call participant', () => {
 
   let promise;
   beforeEach(() => {
-    promise = new CallParticipant(client, { code: 'SYNC', callId: 2, user: '/1/SYNC/users/1' })
+    promise = new CallParticipant(client, { code: 'SYNC', callId: 2, user: { href: '/1/SYNC/users/1' } })
       .create()
       .then(participant => participant.end()
         .then(() => participant));

--- a/src/resources/VoipHeartbeatHandler.js
+++ b/src/resources/VoipHeartbeatHandler.js
@@ -117,19 +117,26 @@ class VoipHeartbeatHandler {
     }
     this.heartbeatTimeoutInterval = setTimeout(this.onHeartbeatTimeout, heartbeatReadTimeoutMs);
 
-    const { desired_call_state: desiredCallState, desired_call_href: desiredCallHref } = heartbeat;
-    const { previousDesiredCallState, previousDesiredCallHref } = this;
+    const {
+      desired_call_state: desiredCallState,
+      desired_call_href: desiredCallHref,
+      is_muted: isMuted = false,
+    } = heartbeat;
+    const { previousDesiredCallState, previousDesiredCallHref, previousIsMuted = false} = this;
 
     const hasDesiredCallStateChanged =
-      desiredCallState !== previousDesiredCallState || desiredCallHref !== previousDesiredCallHref;
+      desiredCallState !== previousDesiredCallState
+      || desiredCallHref !== previousDesiredCallHref
+      || isMuted !== previousIsMuted;
 
     if (hasDesiredCallStateChanged) {
       this.previousDesiredCallState = desiredCallState;
       this.previousDesiredCallHref = desiredCallHref;
+      this.previousIsMuted = isMuted;
 
       const { onDesiredCallStateChange: onChange } = this.handlers;
       if (typeof onChange === 'function') {
-        onChange(desiredCallState, desiredCallHref);
+        onChange(desiredCallState, desiredCallHref, isMuted);
       }
     }
   }
@@ -155,8 +162,9 @@ class VoipHeartbeatHandler {
 
   /**
    * Registers a handler function to be called when the call state changes.
-   * Handler will be called with the desired call state and call href.
-   * @param {function} handler - function(callState, callHref)
+   * Handler will be called with the desired call state, call href, and
+   * whether the connection should be muted.
+   * @param {function} handler - function(callState, callHref, isMuted)
    * @returns {VoipHeartbeatHandler} This VoipHeartbeatHandler
    */
   onDesiredCallStateChange(handler) {

--- a/src/resources/VoipHeartbeatHandler.test.js
+++ b/src/resources/VoipHeartbeatHandler.test.js
@@ -93,10 +93,11 @@ describe('When sending and receiving heartbeats', () => {
     const stateChangePromise = new Promise((resolver) => { stateChangeResolver = resolver; });
 
     subject
-      .onDesiredCallStateChange((callState, callHref) => {
+      .onDesiredCallStateChange((callState, callHref, isMuted) => {
         stateChangeResolver({
           callState,
           callHref,
+          isMuted,
         });
       })
       .startHeartbeat();


### PR DESCRIPTION
VOIP heartbeats sent to users contain a `desiredCallState` that informs
the user whether they should connect to a call.  We've added an
`isMuted` property to these heartbeats to support listen-only call
connections.

This commit exposes the `isMuted` property to VOIP heartbeat handlers.

I also updated the mocks that refer to Users and Vehicles on call
participants to accurately match the Track API models.

Contributes to EN-7644.

Signed-off-by: Jeff Cuevas-Koch <jcuevas-koch@gmvsync.com>