### PR TITLE
Feature/en 9944 dispose all emergencies for vehicle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncromatics-track-api",
-  "version": "3.30.0-development",
+  "version": "3.31.0-development",
   "description": "Library to interact with the Syncromatics Track API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/mocks/incidents.js
+++ b/src/mocks/incidents.js
@@ -9,7 +9,8 @@ const incidents = {
     fetchMock
       .post(client.resolve('/1/SYNC/incidents/1/claim'), singleResponse)
       .post(client.resolve('/1/SYNC/incidents/1/notes'), singleResponse)
-      .post(client.resolve('/1/SYNC/incidents/1/dispose'), singleResponse);
+      .post(client.resolve('/1/SYNC/incidents/1/dispose'), singleResponse)
+      .post(client.resolve('/1/SYNC/incidents/dispose'), singleResponse);
   },
   getById: id => incidents.list.find(v => v.id === id),
   list: [{

--- a/src/mocks/incidents.js
+++ b/src/mocks/incidents.js
@@ -10,7 +10,7 @@ const incidents = {
       .post(client.resolve('/1/SYNC/incidents/1/claim'), singleResponse)
       .post(client.resolve('/1/SYNC/incidents/1/notes'), singleResponse)
       .post(client.resolve('/1/SYNC/incidents/1/dispose'), singleResponse)
-      .post(client.resolve('/1/SYNC/incidents/dispose'), singleResponse);
+      .post(client.resolve('/1/SYNC/incidents/1/disposeMultiple'), singleResponse);
   },
   getById: id => incidents.list.find(v => v.id === id),
   list: [{

--- a/src/resources/Incident.js
+++ b/src/resources/Incident.js
@@ -63,6 +63,19 @@ class Incident extends Resource {
     return this.client.post(`${this.href}/dispose`, { body: dispositionType });
   }
 
+
+  /**
+   * Dispose an incident and all other uncleared incidents from the same vehicle.
+   * Additionally disposed-of incidents will include a note pointing back to the original emergency incident.
+   * Additionally disposed-of incidents will be marked the same as the original emergency incident's disposition type.
+   * @param {number|string} dispositionType Disposition of incident FalseAlarm or Cleared 
+   * @returns {Promise} If successful, indicates if the incident and all other uncleared incidents have been disposed
+   */
+  disposeAllIncidentsFromVehicle(dispositionType) {
+    return this.client.post(`${this.href}/disposeAllFromVehicle`, { body: dispositionType });
+
+  }
+
   /**
    * @deprecated use dispose() instead
    * Dispose an incident

--- a/src/resources/Incident.js
+++ b/src/resources/Incident.js
@@ -57,14 +57,14 @@ class Incident extends Resource {
   /**
    * Dispose an incident or multiple incidents
    * @param {number|string} dispositionType Disposition of incident FalseAlarm or Cleared
-   * @param {string|string[]} incidentIds Single incident ID or an array of incident IDs
+   * @param {string[]} [incidentIds] Optional array of *additional* incident IDs to dispose
    * @returns {Promise} If successful, indicates if the incident(s) has been disposed
    */
   dispose(dispositionType, incidentIds) {
-    if (Array.isArray(incidentIds)) {
+    if (Array.isArray(incidentIds) && incidentIds.length > 0) {
       return this.client.post(`${this.href}/disposeMultiple`, { body: { incidentIds, dispositionType } });
     }
-    
+
     return this.client.post(`${this.href}/dispose`, { body: dispositionType });
 
   }

--- a/src/resources/Incident.js
+++ b/src/resources/Incident.js
@@ -55,24 +55,17 @@ class Incident extends Resource {
   }
 
   /**
-   * Dispose an incident
+   * Dispose an incident or multiple incidents
    * @param {number|string} dispositionType Disposition of incident FalseAlarm or Cleared
-   * @returns {Promise} If successful, indicates if the incident has been disposed
+   * @param {string|string[]} incidentIds Single incident ID or array of incident IDs
+   * @returns {Promise} If successful, indicates if the incident(s) has been disposed
    */
-  dispose(dispositionType) {
+  dispose(dispositionType, incidentIds) {
+    if (Array.isArray(incidentIds)) {
+      return this.client.post(`/1/${this.customerCode}/incidents/dispose`, { body: { incidentIds, dispositionType } });
+    }
+    
     return this.client.post(`${this.href}/dispose`, { body: dispositionType });
-  }
-
-
-  /**
-   * Dispose an incident and all other uncleared incidents from the same vehicle.
-   * Additionally disposed-of incidents will include a note pointing back to the original emergency incident.
-   * Additionally disposed-of incidents will be marked the same as the original emergency incident's disposition type.
-   * @param {number|string} dispositionType Disposition of incident FalseAlarm or Cleared 
-   * @returns {Promise} If successful, indicates if the incident and all other uncleared incidents have been disposed
-   */
-  disposeAllIncidentsFromVehicle(dispositionType) {
-    return this.client.post(`${this.href}/disposeAllFromVehicle`, { body: dispositionType });
 
   }
 

--- a/src/resources/Incident.js
+++ b/src/resources/Incident.js
@@ -57,7 +57,7 @@ class Incident extends Resource {
   /**
    * Dispose an incident or multiple incidents
    * @param {number|string} dispositionType Disposition of incident FalseAlarm or Cleared
-   * @param {string|string[]} incidentIds Single incident ID or array of incident IDs
+   * @param {string|string[]} incidentIds Single incident ID or an array of incident IDs
    * @returns {Promise} If successful, indicates if the incident(s) has been disposed
    */
   dispose(dispositionType, incidentIds) {

--- a/src/resources/Incident.js
+++ b/src/resources/Incident.js
@@ -62,7 +62,7 @@ class Incident extends Resource {
    */
   dispose(dispositionType, incidentIds) {
     if (Array.isArray(incidentIds)) {
-      return this.client.post(`/1/${this.customerCode}/incidents/dispose`, { body: { incidentIds, dispositionType } });
+      return this.client.post(`${this.href}/disposeMultiple`, { body: { incidentIds, dispositionType } });
     }
     
     return this.client.post(`${this.href}/dispose`, { body: dispositionType });

--- a/src/resources/Incident.test.js
+++ b/src/resources/Incident.test.js
@@ -69,3 +69,16 @@ describe('When disposing an incident', () => {
     return promise.should.be.fulfilled;
   });
 });
+
+describe('When disposing multiple incidents', () => {
+  const client = new Client();
+  beforeEach(() => mockIncidents.setUpSuccessfulMock(client));
+  beforeEach(() => fetchMock.catch(503));
+  afterEach(fetchMock.restore);
+  let promise;
+  beforeEach(() => {
+    promise = new Incident(client, Incident.makeHref('SYNC', 1)).dispose('Cleared', [1, 2, 3]);
+  });
+
+  it('should resolve the promise', () => promise.should.be.fulfilled);
+});

--- a/src/resources/Incident.test.js
+++ b/src/resources/Incident.test.js
@@ -77,7 +77,9 @@ describe('When disposing multiple incidents', () => {
   afterEach(fetchMock.restore);
   let promise;
   beforeEach(() => {
-    promise = new Incident(client, Incident.makeHref('SYNC', 1)).dispose('Cleared', [1, 2, 3]);
+    const primaryIncidentId = 1;
+    const additionalToDismissWithPrimary = [2, 3];
+    promise = new Incident(client, Incident.makeHref('SYNC', primaryIncidentId)).dispose('Cleared', additionalToDismissWithPrimary);
   });
 
   it('should resolve the promise', () => promise.should.be.fulfilled);


### PR DESCRIPTION
Adds parameter to incidents().dispose() function. Dispose additional incidents by giving it a list of incident IDs as the 2nd parameter. These incidents are disposed but a note is also added to each one that states they were dismissed with the primary incident ID.

Code example.

```js
// Normal way to dismiss an emergency
var primaryIncidentId = "abc-123";
var disposalType = 1;
incidents(primaryIncidentId).dispose(disposalType);

// New way to dismiss many other incidents with the primary incident
var additionalIncidentIds = ["def-456", "ghi-789"];
incidents(primaryIncidentId).dispose(disposalType, additionalIncidentIds);
```