### PR TITLE
Feature/EN-9981-detour-aware-service-package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "syncromatics-track-api",
-  "version": "3.31.1-development",
+  "version": "3.31.2-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "syncromatics-track-api",
-  "version": "3.29.5",
+  "version": "3.31.1-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncromatics-track-api",
-  "version": "3.31.0-development",
+  "version": "3.31.1-development",
   "description": "Library to interact with the Syncromatics Track API",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncromatics-track-api",
-  "version": "3.31.1-development",
+  "version": "3.31.2-development",
   "description": "Library to interact with the Syncromatics Track API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/examples/get_service.test.js
+++ b/src/examples/get_service.test.js
@@ -18,24 +18,9 @@ describe('When retrieving a service by ID', () => {
   it('should get a service', () => {
     api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
 
-    const servicePromise = api
-      .customer('SYNC')
-      .service(1)
+    const servicePromise = api.customer('SYNC').service(1)
       .fetch()
-      .then((service) => service); // Do things with run
-
-    return servicePromise;
-  });
-
-  it('should get a service with active detours', () => {
-    api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
-
-    const includeDetours = true;
-    const servicePromise = api
-      .customer('SYNC')
-      .service(1, includeDetours)
-      .fetch()
-      .then((service) => service); // Do things with run
+      .then(service => service); // Do things with run
 
     return servicePromise;
   });

--- a/src/examples/get_service.test.js
+++ b/src/examples/get_service.test.js
@@ -18,9 +18,24 @@ describe('When retrieving a service by ID', () => {
   it('should get a service', () => {
     api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
 
-    const servicePromise = api.customer('SYNC').service(1)
+    const servicePromise = api
+      .customer('SYNC')
+      .service(1)
       .fetch()
-      .then(service => service); // Do things with run
+      .then((service) => service); // Do things with run
+
+    return servicePromise;
+  });
+
+  it('should get a service with active detours', () => {
+    api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
+
+    const includeDetours = true;
+    const servicePromise = api
+      .customer('SYNC')
+      .service(1, includeDetours)
+      .fetch()
+      .then((service) => service); // Do things with run
 
     return servicePromise;
   });

--- a/src/mocks/services.js
+++ b/src/mocks/services.js
@@ -4,9 +4,11 @@ import Client from '../Client';
 
 const services = {
   setUpSuccessfulMock: (client) => {
-    const singleResponse = () => new Response(Client.toBlob(services.getById(1)));
+    const singleDefaultResponse = () => new Response(Client.toBlob(services.getById(1)));
     fetchMock
-      .get(client.resolve('/1/SYNC/services/1'), singleResponse);
+        .get(client.resolve('/1/SYNC/services/1'), singleDefaultResponse)
+        .get(client.resolve('/1/SYNC/services/1?includeDetours=false'), singleDefaultResponse)
+        .get(client.resolve('/1/SYNC/services/1?includeDetours=true'), singleDefaultResponse);
   },
   getById: id => services.list.find(s => s.id === id),
   list: [

--- a/src/resources/Customer.js
+++ b/src/resources/Customer.js
@@ -438,10 +438,11 @@ class Customer extends Resource {
   /**
    * Gets a Service resource by ID
    * @param {Number} id Identity of the service
+   * @param {Boolean} includeDetours Package trips reflect active detours instead of the regular service
    * @returns {Service} Service resource
    */
-  service(id) {
-    return this.resource(Service, Service.makeHref(this.code, id));
+  service(id, includeDetours = false) {
+    return this.resource(Service, Service.makeHref(this.code, id, includeDetours));
   }
 
   /**

--- a/src/resources/Customer.js
+++ b/src/resources/Customer.js
@@ -438,11 +438,10 @@ class Customer extends Resource {
   /**
    * Gets a Service resource by ID
    * @param {Number} id Identity of the service
-   * @param {Boolean} includeDetours Package trips reflect active detours instead of the regular service
    * @returns {Service} Service resource
    */
-  service(id, includeDetours = false) {
-    return this.resource(Service, Service.makeHref(this.code, id, includeDetours));
+  service(id) {
+    return this.resource(Service, Service.makeHref(this.code, id));
   }
 
   /**

--- a/src/resources/Service.js
+++ b/src/resources/Service.js
@@ -3,7 +3,6 @@ import Block from './Block';
 import Run from './Run';
 import Trip from './Trip';
 
-
 /**
  * Service resource
  */
@@ -31,11 +30,11 @@ class Service extends Resource {
     super(client);
 
     const newProperties = Object.assign({}, ...rest);
-    const hydrated = !Object.keys(newProperties).every(k => k === 'href');
+    const hydrated = !Object.keys(newProperties).every((k) => k === 'href');
     const references = {
-      blocks: newProperties.blocks && newProperties.blocks.map(b => new Block(this.client, b)),
-      runs: newProperties.runs && newProperties.runs.map(r => new Run(this.client, r)),
-      trips: newProperties.trips && newProperties.trips.map(t => new Trip(this.client, t)),
+      blocks: newProperties.blocks && newProperties.blocks.map((b) => new Block(this.client, b)),
+      runs: newProperties.runs && newProperties.runs.map((r) => new Run(this.client, r)),
+      trips: newProperties.trips && newProperties.trips.map((t) => new Trip(this.client, t)),
     };
 
     Object.assign(this, newProperties, {
@@ -48,11 +47,12 @@ class Service extends Resource {
    * Makes a href for a given customer code and ID
    * @param {string} customerCode Customer code
    * @param {Number} id Service ID
+   * @param {Boolean} [includeDetours=false] Include detours in the response (optional)
    * @returns {{href: string}} URI to instance of Service
    */
-  static makeHref(customerCode, id) {
+  static makeHref(customerCode, id, includeDetours = false) {
     return {
-      href: `/1/${customerCode}/services/${id}`,
+      href: `/1/${customerCode}/services/${id}?includeDetours=${includeDetours}`,
     };
   }
 
@@ -61,9 +61,10 @@ class Service extends Resource {
    * @returns {Promise} If successful, a hydrated instance of this Service
    */
   fetch() {
-    return this.client.get(this.href)
-      .then(response => response.json())
-      .then(service => new Service(this.client, this, service));
+    return this.client
+      .get(this.href)
+      .then((response) => response.json())
+      .then((service) => new Service(this.client, this, service));
   }
 }
 

--- a/src/resources/Service.js
+++ b/src/resources/Service.js
@@ -3,6 +3,7 @@ import Block from './Block';
 import Run from './Run';
 import Trip from './Trip';
 
+
 /**
  * Service resource
  */
@@ -30,11 +31,11 @@ class Service extends Resource {
     super(client);
 
     const newProperties = Object.assign({}, ...rest);
-    const hydrated = !Object.keys(newProperties).every((k) => k === 'href');
+    const hydrated = !Object.keys(newProperties).every(k => k === 'href');
     const references = {
-      blocks: newProperties.blocks && newProperties.blocks.map((b) => new Block(this.client, b)),
-      runs: newProperties.runs && newProperties.runs.map((r) => new Run(this.client, r)),
-      trips: newProperties.trips && newProperties.trips.map((t) => new Trip(this.client, t)),
+      blocks: newProperties.blocks && newProperties.blocks.map(b => new Block(this.client, b)),
+      runs: newProperties.runs && newProperties.runs.map(r => new Run(this.client, r)),
+      trips: newProperties.trips && newProperties.trips.map(t => new Trip(this.client, t)),
     };
 
     Object.assign(this, newProperties, {
@@ -47,12 +48,11 @@ class Service extends Resource {
    * Makes a href for a given customer code and ID
    * @param {string} customerCode Customer code
    * @param {Number} id Service ID
-   * @param {Boolean} [includeDetours=false] Include detours in the response (optional)
    * @returns {{href: string}} URI to instance of Service
    */
-  static makeHref(customerCode, id, includeDetours = false) {
+  static makeHref(customerCode, id) {
     return {
-      href: `/1/${customerCode}/services/${id}?includeDetours=${includeDetours}`,
+      href: `/1/${customerCode}/services/${id}`,
     };
   }
 
@@ -61,10 +61,9 @@ class Service extends Resource {
    * @returns {Promise} If successful, a hydrated instance of this Service
    */
   fetch() {
-    return this.client
-      .get(this.href)
-      .then((response) => response.json())
-      .then((service) => new Service(this.client, this, service));
+    return this.client.get(this.href)
+      .then(response => response.json())
+      .then(service => new Service(this.client, this, service));
   }
 }
 

--- a/src/resources/Service.test.js
+++ b/src/resources/Service.test.js
@@ -12,7 +12,7 @@ describe('When instantiating a service based on customer and ID', () => {
   const client = new Client();
   const service = new Service(client, Service.makeHref('SYNC', 1));
 
-  it('should set the href', () => service.href.should.equal('/1/SYNC/services/1'));
+  it('should set the href', () => service.href.should.equal('/1/SYNC/services/1?includeDetours=false'));
   it('should not be hydrated', () => service.hydrated.should.equal(false));
 });
 


### PR DESCRIPTION
Allow an optional bool argument of `includeDetours` to indicate to Track-API that it should return an updated schedule that takes detours into consideration (swapping out routeId where and including a detourId for trips where appropriate).