### PR TITLE
EN-9508 Add Expandable Properties to Get Pattern property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncromatics-track-api",
-  "version": "3.32.0",
+  "version": "3.33.0",
   "description": "Library to interact with the Syncromatics Track API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/examples/get_patterns.test.js
+++ b/src/examples/get_patterns.test.js
@@ -104,4 +104,34 @@ describe('When retrieving a pattern by ID', () => {
 
     return patternsPromise;
   });
+
+  it('should get a pattern with expanded stops', () => {
+    api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
+
+    const patternsPromise = api.customer('SYNC').pattern(1, { expandStops: true })
+      .fetch()
+      .then(pattern => pattern); // Do things with pattern
+
+    return patternsPromise;
+  });
+
+  it('should get a pattern with expanded route', () => {
+    api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
+
+    const patternsPromise = api.customer('SYNC').pattern(1, { expandRoute: true })
+      .fetch()
+      .then(pattern => pattern); // Do things with pattern
+
+    return patternsPromise;
+  });
+
+  it('should get a pattern with expanded stops and route', () => {
+    api.logIn({ username: 'charlie@example.com', password: 'securepassword' });
+
+    const patternsPromise = api.customer('SYNC').pattern(1, { expandStops: true, expandRoute: true })
+      .fetch()
+      .then(pattern => pattern); // Do things with pattern
+
+    return patternsPromise;
+  });
 });

--- a/src/mocks/patterns.js
+++ b/src/mocks/patterns.js
@@ -29,7 +29,10 @@ const patterns = {
       .get(client.resolve('/1/SYNC/patterns?page=1&per_page=10&enabled_for_operations=true&as_of=2018-03-05T00%3A00%3A00.000Z&sort='), listResponse)
       .get(client.resolve('/1/SYNC/patterns?page=1&per_page=10&expand=stops&sort='), listResponseWithStops)
       .get(client.resolve('/1/SYNC/patterns?page=1&per_page=10&expand=stops&enabled_for_operations=true&as_of=2018-03-05T00%3A00%3A00.000Z&sort='), listResponseWithStops)
-      .get(client.resolve('/1/SYNC/patterns/1'), singleResponse);
+      .get(client.resolve('/1/SYNC/patterns/1'), singleResponse)
+      .get(client.resolve('/1/SYNC/patterns/1?expand=stops'), singleResponse)
+      .get(client.resolve('/1/SYNC/patterns/1?expand=route'), singleResponse)
+      .get(client.resolve('/1/SYNC/patterns/1?expand=stops,route'), singleResponse);
   },
   getById: id => patterns.list
     .map(p => ({ ...p,

--- a/src/resources/Customer.js
+++ b/src/resources/Customer.js
@@ -403,10 +403,13 @@ class Customer extends Resource {
   /**
    * Gets a pattern resource by id
    * @param {Number} id Identity of the pattern
+   * @param {Object} [options] Options for expanding the pattern
+   * @param {boolean} [options.expandStops] Expand stops
+   * @param {boolean} [options.expandRoute] Expand route
    * @returns {Pattern} Pattern resource
    */
-  pattern(id) {
-    return this.resource(Pattern, Pattern.makeHref(this.code, id));
+  pattern(id, options) {
+    return this.resource(Pattern, Pattern.makeHref(this.code, id, options));
   }
 
   /**

--- a/src/resources/Pattern.js
+++ b/src/resources/Pattern.js
@@ -40,11 +40,19 @@ class Pattern extends Resource {
    * Makes a href for a given customer code and ID
    * @param {string} customerCode Customer code
    * @param {Number} id Pattern ID
+   * @param {Object} [options] Options for expanding the pattern
+   * @param {boolean} [options.expandStops] Expand stops
+   * @param {boolean} [options.expandRoute] Expand route
    * @returns {string} URI to instance of pattern
    */
-  static makeHref(customerCode, id) {
+  static makeHref(customerCode, id, options) {
+    const { expandStops, expandRoute} = options || {};
+    const expanded = [
+      expandStops && 'stops',
+      expandRoute && 'route',
+    ].filter(Boolean).join(',');
     return {
-      href: `/1/${customerCode}/patterns/${id}`,
+      href: `/1/${customerCode}/patterns/${id}${expanded ? `?expand=${expanded}` : ''}`,
     };
   }
 

--- a/src/resources/Pattern.test.js
+++ b/src/resources/Pattern.test.js
@@ -46,3 +46,25 @@ describe('When fetching a pattern based on customer and ID', () => {
   it('should have six stops', () => promise.then(p => p.stops.length).should.eventually.equal(6));
   it('should have the expected route', () => promise.then(p => p.route.href).should.eventually.equal('/1/SYNC/routes/1'));
 });
+
+describe('When fetching a pattern with expanded options that is based on customer and ID', () => {
+  it('should generate href with expand stops', () => {
+    const href = Pattern.makeHref('SYNC', 1, { expandStops: true }).href;
+    href.should.equal('/1/SYNC/patterns/1?expand=stops');
+  });
+
+  it('should generate href with expand route', () => {
+    const href = Pattern.makeHref('SYNC', 1, { expandRoute: true }).href;
+    href.should.equal('/1/SYNC/patterns/1?expand=route');
+  });
+
+  it('should generate href with expand stops and route', () => {
+    const href = Pattern.makeHref('SYNC', 1, { expandStops: true, expandRoute: true }).href;
+    href.should.equal('/1/SYNC/patterns/1?expand=stops,route');
+  });
+
+  it('should generate href without expand options', () => {
+    const href = Pattern.makeHref('SYNC', 1).href;
+    href.should.equal('/1/SYNC/patterns/1');
+  });
+});


### PR DESCRIPTION
Apiary docs state that, when getting a single pattern by ID, you can append `?expand=stops,route` to retrieve a more filled-out response object with the related values to the route and stops.

This PR focuses on adding an `options` object to `customer().pattern()` to provide two new options: `expandStops` and `expandRoute`. Options can be left undefined as can each property inside the options.

Tests have been added to the PR to demonstrate the usage.